### PR TITLE
fix for read only access problem

### DIFF
--- a/source/introduction/logging.rst
+++ b/source/introduction/logging.rst
@@ -26,7 +26,7 @@ ninja.log is used by Go code.  It is very useful to see what is going on in the 
 	
 	.. code-block:: bash
 
-		sudo vi /etc/rsyslog.d/10-ninja.conf
+		sudo with-rw nano /etc/rsyslog.d/10-ninja.conf
 
 
 /var/log/ninjasphere.log


### PR DESCRIPTION
with 'sudo vi /etc/rsyslog.d/10-ninja.conf' the file is readonly.

I made a change to go into bash with write permissions and also changed the editor from vi to nano which should be easier to handle for newbies.
